### PR TITLE
Adds vehicle registration expiry tracking

### DIFF
--- a/lib/validators/transport/vehicleCreateSchema.ts
+++ b/lib/validators/transport/vehicleCreateSchema.ts
@@ -6,6 +6,12 @@ export const createVehicleSchema = Joi.object({
   model: Joi.string().max(255).required(),
   buyDate: Joi.date().optional().allow(null).allow(''),
   transport: Joi.string().max(255).optional().allow(null).allow(''),
+  mulkiyaRegistrationExpiry: Joi.date()
+    .optional()
+    .allow(null)
+    .allow('')
+    .greater('now')
+    .messages({ 'date.greater': 'Mulkiya registration expiry must be in the future' }),
 });
 
 export const createVehicleReservationSchema = Joi.object({

--- a/middleware/transport/vehicleValidators.ts
+++ b/middleware/transport/vehicleValidators.ts
@@ -11,6 +11,10 @@ const extractVehicleData = (payload: Partial<TransportVehicle>) => {
     buyDate: payload.buyDate ? new Date(payload.buyDate) : null,
     transport: payload.transport ?? null,
     mulkiyaFilePath: payload.mulkiyaFilePath ?? null,
+    // Casting payload to any for newly added field until Prisma types regenerated
+    mulkiyaRegistrationExpiry: (payload as any).mulkiyaRegistrationExpiry
+      ? new Date((payload as any).mulkiyaRegistrationExpiry)
+      : null,
   };
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lucky-brothers-backend",
-  "version": "6.2.1",
+  "version": "7.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "lucky-brothers-backend",
-      "version": "6.2.1",
+      "version": "7.0.0",
       "dependencies": {
         "@prisma/client": "^5.22.0",
         "@sentry/node": "^8.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lucky-brothers-backend",
-  "version": "6.2.1",
+  "version": "7.0.0",
   "private": true,
   "scripts": {
     "bump-version-patch": "npm version patch --no-git-tag-version",

--- a/prisma/repositories/transport/vehicles/saveVehicle.ts
+++ b/prisma/repositories/transport/vehicles/saveVehicle.ts
@@ -8,8 +8,12 @@ export const saveVehicle= async (entry: TransportVehicle): Promise<TransportVehi
 const saveVehicleEntry = async (entry: TransportVehicle): Promise<TransportVehicle | null> => {
   return prisma.$transaction(async (tx) => {
     // 1 save vehicle
+    const data: any = { ...entry };
+    if (entry.mulkiyaRegistrationExpiry !== undefined) {
+      data.mulkiyaRegistrationExpiry = entry.mulkiyaRegistrationExpiry || null;
+    }
     const entryCreated = await tx.transportVehicle.create({
-      data: entry,
+      data,
     });
 
     return entryCreated;

--- a/prisma/repositories/transport/vehicles/updateVehicle.ts
+++ b/prisma/repositories/transport/vehicles/updateVehicle.ts
@@ -19,6 +19,9 @@ const updateVehicleEntry = async (entry: TransportVehicle): Promise<TransportVeh
         buyDate: entry.buyDate,
         transport: entry.transport,
         mulkiyaFilePath: entry.mulkiyaFilePath,
+        ...(entry.mulkiyaRegistrationExpiry !== undefined && {
+          mulkiyaRegistrationExpiry: entry.mulkiyaRegistrationExpiry || null,
+        }),
       },
     });
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -398,6 +398,7 @@ model TransportVehicle {
   buyDate              DateTime?                      @db.DateTime
   transport            String?                        @db.VarChar(255) // Transport through which vehicle is bought
   mulkiyaFilePath      String?                        @db.VarChar(255)
+  mulkiyaRegistrationExpiry DateTime?                 @db.DateTime
   createdAt            DateTime                       @default(now())
   updatedAt            DateTime                       @updatedAt
   createdById          Int?                           @db.Int


### PR DESCRIPTION
Introduces an optional future‑dated registration expiry field to support monitoring and proactive renewal of vehicle documents. Enforces future date validation to prevent storing already expired registrations and normalizes null handling in persistence.

Updates extraction and save/update logic to include the new field and temporarily casts types pending regenerated ORM typings. Bumps major version to signal the schema evolution.